### PR TITLE
provisional patching to restore shiny

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,12 +34,9 @@ ENV DATABASECONNECTOR_JAR_FOLDER="/usr/local/lib/DatabaseConnectorJars"
 RUN set -eux; \
   Rscript \
     -e 'renv::activate("/app")' \
+    -e 'renv::install("shiny")' \
     -e 'library(DatabaseConnector)' \
-    -e 'downloadJdbcDrivers("oracle")' \
-    -e 'downloadJdbcDrivers("postgresql")' \
-    -e 'downloadJdbcDrivers("redshift")' \
-    -e 'downloadJdbcDrivers("spark")' \
-    -e 'downloadJdbcDrivers("sql server")' \
+    -e 'downloadJdbcDrivers("all")' \
   ;
 
 WORKDIR /output

--- a/renv.txt
+++ b/renv.txt
@@ -3,3 +3,4 @@ OHDSI/DataQualityDashboard
 OHDSI/DatabaseConnector
 docopt
 stringr
+shiny


### PR DESCRIPTION
`shiny` is now merely a "suggested" package in upstream, this is a quick patch to restore it to our container